### PR TITLE
chore: export Workspace and FileSystem as a value instead of type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 import type * as monacoNS from "./monaco.d.ts";
 import type { LSPConfig } from "./lsp.d.ts";
 import type { TextmateGrammarName, TextmateThemeName } from "./textmate.d.ts";
-import type { ErrorNotFound, FileSystem, Workspace } from "./workspace.d.ts";
+import { ErrorNotFound, FileSystem, Workspace } from "./workspace";
 
 type Awaitable<T> = T | Promise<T>;
 type MaybeGetter<T> = Awaitable<MaybeModule<T>> | (() => Awaitable<MaybeModule<T>>);


### PR DESCRIPTION
Otherwise when using it throws an error in ts

```ts
import { lazy, Workspace } from 'modern-monaco';
const workspace = new Workspace({
//                    ^ "Workspace" is imported using "import type", and cannot be used as a value
//                      index.d.ts (4, 42): "Workspace" imported here
```