### PR TITLE
fix production usage with bundlers (fix #14, fix #15)

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -389,13 +389,7 @@ async function loadMonaco(
       if (!provider) {
         provider = Object.values(lspProviderMap).find((p) => p.aliases?.includes(label));
       }
-      const url = provider ? (await provider.import()).getWorkerUrl() : monaco.getWorkerUrl();
-      if (label === "typescript") {
-        const tsVersion = lsp?.typescript?.tsVersion;
-        if (tsVersion && (url.hostname === "esm.sh" || url.hostname.endsWith(".esm.sh"))) {
-          url.searchParams.set("deps", `typescript@${tsVersion}`);
-        }
-      }
+      const url = provider ? (await provider.import()).getWorker(lsp?.[label] || {}) : monaco.getWorker();
       const worker = createWebWorker(url, undefined);
       if (!provider) {
         const onMessage = (e: MessageEvent) => {

--- a/src/editor-core.ts
+++ b/src/editor-core.ts
@@ -179,11 +179,8 @@ export function showQuickPick(items: any[], options: QuickPickOptions = {}) {
   });
 }
 
-export function getWorkerUrl() {
-  const i = () => import("./editor-worker.js"); // trick for bundlers
-  const m = getWorkerUrl.toString().match(/import\(['"](.+?)['"]\)/);
-  if (!m) throw new Error("worker url not found", { cause: i });
-  return new URL(m[1], import.meta.url);
+export function getWorker() {
+  return new Worker(new URL("./editor-worker.js", import.meta.url), { type: "module" });
 }
 
 export const languageConfigurationAliases: Record<string, string> = {

--- a/src/lsp/css/setup.ts
+++ b/src/lsp/css/setup.ts
@@ -46,9 +46,6 @@ export async function setup(
   ls.registerDocumentLinks(languageId, worker);
 }
 
-export function getWorkerUrl() {
-  const i = () => import("./worker.js"); // trick for bundlers
-  const m = getWorkerUrl.toString().match(/import\(['"](.+?)['"]\)/);
-  if (!m) throw new Error("worker url not found", { cause: i });
-  return new URL(m[1], import.meta.url);
+export function getWorker() {
+  return new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
 }

--- a/src/lsp/html/setup.ts
+++ b/src/lsp/html/setup.ts
@@ -97,9 +97,6 @@ export async function setup(
   });
 }
 
-export function getWorkerUrl() {
-  const i = () => import("./worker.js"); // trick for bundlers
-  const m = getWorkerUrl.toString().match(/import\(['"](.+?)['"]\)/);
-  if (!m) throw new Error("worker url not found", { cause: i });
-  return new URL(m[1], import.meta.url);
+export function getWorker() {
+  return new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
 }

--- a/src/lsp/index.ts
+++ b/src/lsp/index.ts
@@ -10,7 +10,7 @@ export interface LSP {
     langaugeSettings?: Record<string, unknown>,
     formattingOptions?: FormattingOptions,
   ) => void | Promise<void>;
-  getWorkerUrl: () => URL;
+  getWorker: (config: any) => URL | Worker;
 }
 
 export interface LSPProvider {
@@ -45,7 +45,10 @@ export const builtinLSPProviders: Record<string, LSPProvider> = {
   },
 };
 
-export function createWebWorker(url: URL, name?: string): Worker {
+export function createWebWorker(url: URL | Worker, name?: string): Worker {
+  if (url instanceof Worker) {
+    return url;
+  }
   let workerUrl: URL | string = url;
   // create a blob url for cross-origin workers if the url is not same-origin
   if (url.origin !== location.origin) {

--- a/src/lsp/json/setup.ts
+++ b/src/lsp/json/setup.ts
@@ -160,9 +160,6 @@ async function searchPackagesFromNpm(keyword: string, size = 20) {
   return items.slice(0, len);
 }
 
-export function getWorkerUrl() {
-  const i = () => import("./worker.js"); // trick for bundlers
-  const m = getWorkerUrl.toString().match(/import\(['"](.+?)['"]\)/);
-  if (!m) throw new Error("worker url not found", { cause: i });
-  return new URL(m[1], import.meta.url);
+export function getWorker() {
+  return new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
 }

--- a/src/lsp/typescript/setup.ts
+++ b/src/lsp/typescript/setup.ts
@@ -52,7 +52,7 @@ export async function setup(
 export function getWorker(config: { tsVersion?: string }) {
   try {
     if (new URL(import.meta.url).hostname === "esm.sh" || new URL(import.meta.url).hostname.endsWith(".esm.sh")) {
-      return new Worker(new URL(`./worker.js?deps=typescript@${config.tsVersion}`, import.meta.url), { type: "module" });
+      return new Worker(`./worker.mjs?deps=typescript@${config.tsVersion}`, { type: "module" });
     }
   } catch (e) {
     console.error("import.meta.url not available", import.meta.url, e);

--- a/src/lsp/typescript/setup.ts
+++ b/src/lsp/typescript/setup.ts
@@ -49,11 +49,15 @@ export async function setup(
   // languages.registerLinkedEditingRangeProvider(languageId, new lfs.LinkedEditingRangeAdapter(worker));
 }
 
-export function getWorkerUrl() {
-  const i = () => import("./worker.js"); // trick for bundlers
-  const m = getWorkerUrl.toString().match(/import\(['"](.+?)['"]\)/);
-  if (!m) throw new Error("worker url not found", { cause: i });
-  return new URL(m[1], import.meta.url);
+export function getWorker(config: { tsVersion?: string }) {
+  try {
+    if (new URL(import.meta.url).hostname === "esm.sh" || new URL(import.meta.url).hostname.endsWith(".esm.sh")) {
+      return new Worker(new URL(`./worker.js?deps=typescript@${config.tsVersion}`, import.meta.url), { type: "module" });
+    }
+  } catch (e) {
+    console.error("import.meta.url not available", import.meta.url, e);
+  }
+  return new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
 }
 
 /** Create the typescript worker. */

--- a/types/lsp.d.ts
+++ b/types/lsp.d.ts
@@ -74,7 +74,7 @@ export interface LSP {
     formattingOptions?: Record<string, unknown>,
     workspace?: Workspace,
   ) => Promise<void>;
-  getWorkerUrl: () => URL;
+  getWorker: () => URL | Worker;
 }
 
 export interface LSPProvider {


### PR DESCRIPTION
Using the original way, the resource was imported into whatever resource **bundle**, meaning that the url contains not only the requested worker, but lots of other modules (vite dev mode don't perform a bundle action so it works like magic in dev but broke in production).
Need to use a way to tell bundlers that it needs to be a seperate chunk and it runs in a worker environment (otherwise some bundlers might inject some dependency management stuff using non-exist `document` variable)
Luckily most bundlers understand `new Worker(new URL(src, import.meta.url))` syntax:

- https://vite.dev/guide/features.html#web-workers
- https://webpack.js.org/guides/web-workers/
- https://parceljs.org/languages/javascript/#web-workers

Integration on esm.sh might need to be tested as I don't know how it processes those code
