### PR TITLE
Fix missing colon in protocol check

### DIFF
--- a/src/shiki.ts
+++ b/src/shiki.ts
@@ -88,7 +88,7 @@ function loadTMTheme(src: string | URL, cdn = "https://esm.sh") {
     return cache.fetch(url).then((res) => res.json());
   }
   const url = typeof src === "string" ? new URL(src, globalThis.location?.href) : src;
-  if (url.protocol === "http" || url.protocol === "https") {
+  if (url.protocol === "http:" || url.protocol === "https:") {
     return cache.fetch(url).then((res) => res.json());
   }
   throw new Error(`Unsupported theme source: ${src}`);
@@ -104,7 +104,7 @@ function loadTMGrammar(src: string | URL, cdn = "https://esm.sh") {
     }
   }
   const url = typeof src === "string" ? new URL(src, globalThis.location?.href) : src;
-  if (url.protocol === "http" || url.protocol === "https") {
+  if (url.protocol === "http:" || url.protocol === "https:") {
     return cache.fetch(url).then((res) => res.json());
   }
   throw new Error(`Unsupported grammar source: ${src}`);


### PR DESCRIPTION
```javascript
console.log(location.protocol); // https:
```