### PR TITLE
fix Next.js Turbopack error `TypeError: __turbopack_context__.x is not a function`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -373,8 +373,8 @@ async function loadMonaco(
 
   const useBuiltinLSP = (globalThis as any).MonacoEnvironment?.useBuiltinLSP;
   const [monaco, { builtinLSPProviders }]: [typeof import("./editor-core"), typeof import("./lsp")] = await Promise.all([
-    import(editorCoreModuleUrl),
-    useBuiltinLSP ? import(lspModuleUrl) : Promise.resolve({ builtinLSPProviders: {} }),
+    import(/* webpackIgnore: true */ editorCoreModuleUrl),
+    useBuiltinLSP ? import(/* webpackIgnore: true */ lspModuleUrl) : Promise.resolve({ builtinLSPProviders: {} }),
   ]);
   const allLspProviders = { ...builtinLSPProviders, ...lspProviders, ...lsp?.providers };
 


### PR DESCRIPTION
currently it's impossible to use `modern-monaco` in Next.js 
<img width="2384" height="242" alt="image" src="https://github.com/user-attachments/assets/05c2e9a9-4b8e-49fd-a230-d72c373d0af7" />

`webpackIgnore: true` comment will indicate to not try to bundle modules at build time