### PR TITLE
Update `sideEffects: ["dist/index.mjs"]` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "process": false,
     "buffer": false
   },
-  "sideEffects": false,
+  "sideEffects": ["dist/index.mjs"],
   "devDependencies": {
     "@esm.sh/import-map": "0.1.1",
     "@shikijs/core": "3.17.0",


### PR DESCRIPTION
in Next.js default lsp doesn't work due `sideEffects: false`

<img width="216" height="112" alt="image" src="https://github.com/user-attachments/assets/d5dbb07f-de77-4d6f-a537-5dc5d427cdd0" />

you have side effect here

https://github.com/esm-dev/modern-monaco/blob/c5a540c5d9152307960e248c25f8685983ee3101/src/index.ts#L16-L19